### PR TITLE
Revert "Revert "Update the order search endpoint for statuses""

### DIFF
--- a/_ordering/get_order_list.md
+++ b/_ordering/get_order_list.md
@@ -13,7 +13,8 @@ right_code: |
       "key": "uuid",
       "dir": "des"
     },
-    "status": "New",
+    "line_item_status": [],
+    "status_conjuction": "or",
     "start_date": "2017-07-31T06:00:00.000Z",
     "end_date": "2018-08-03T06:00:00.000Z"
   }
@@ -362,8 +363,11 @@ limit
 sort
 : (object) The Sort object contains a Key to sort on and a Direction (dir) to sort in
 
-status
-: (string) The Status of the Orders you would like to see returned
+line_item_status
+: (array) One or more line item statuses: unallocated, allocated, has_tracking, backordered, rejected. The response will contain orders with statuses that match the provided line_item_status (as combined based on status_conjunction)
+
+status_conjunction
+: (string) Determines whether search for line_item_status returns orders with a union, intersection, or complement of statuses. Possible values: and, or, only. Default: or. The conjunction determines whether we return every order that contains all (and), at least one (or), or only (only) the provided line-item-status(es). For conjunction only, line_item_status must have exactly one line-item-status.
 
 start_date
 : (string) The Start Date for your search results. The date must be written in the following format "YYYY-MM-DDThh:mm:ss.000Z"


### PR DESCRIPTION
Reverts DobaTech/thanos-api-docs#66

Shouldn't be released until DobaTech/thanos#687 is released.