### PR TITLE
Remove base url.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ description: API documentation for project codenamed thanos
 url: https://example.com
 google_analytics_key:
 permalink: pretty
-baseurl: /crux-api-docs
+baseurl: /
 
 collections:
   documentation:


### PR DESCRIPTION
the docs now have a custom domain and the baseurl is no longer needed.