### PR TITLE
Remove the line_item_status and related

### DIFF
--- a/_ordering/get_orders.md
+++ b/_ordering/get_orders.md
@@ -13,10 +13,6 @@ right_code: |
       "key": "uuid",
       "dir": "des"
     },
-    "line_item_status": [
-      "unallocated"
-    ],
-    "status_conjunction": "or",
     "start_date": "2017-07-31T06:00:00.000Z",
     "end_date": "2018-08-03T06:00:00.000Z"
   }
@@ -330,12 +326,6 @@ limit
 sort
 : (object) The Sort object contains a Key to sort on and a Direction (dir) to sort in
 
-line_item_status
-: (array) One or more line item statuses: unallocated, allocated, has_tracking, backordered, rejected. The response will contain orders with statuses that match the provided line_item_status (as combined based on status_conjunction)
-
-status_conjunction
-: (string) Determines whether search for line_item_status returns orders with a union, intersection, or complement of statuses. Possible values: and, or, only. Default: or. The conjunction determines whether we return every order that contains all (and), at least one (or), or only (only) the provided line-item-status(es). For conjunction only, line_item_status must have exactly one line-item-status.
-
 start_date
 : (string) The Start Date for your search results. The date must be written in the following format "YYYY-MM-DDThh:mm:ss.000Z"
 
@@ -521,12 +511,8 @@ curl -X "POST" "https://api.cruxconnect.com/api/orders/" \
     "dir": "des"
   },
   "start": 0,
-  "status_conjunction": "or",
   "start_date": "2017-07-31T06:00:00.000Z",
   "limit": 25,
-  "line_item_status": [
-    "unallocated"
-  ],
   "end_date": "2018-08-03T06:00:00.000Z"
 }'
 
@@ -542,12 +528,8 @@ http --json POST 'https://api.cruxconnect.com/api/orders/' \
   \"dir\": \"des\"
 }" \
     start:=0 \
-    status_conjunction="or" \
     start_date="2017-07-31T06:00:00.000Z" \
     limit:=25 \
-    line_item_status:="[
-  \"unallocated\"
-]" \
     end_date="2018-08-03T06:00:00.000Z"
 
 ~~~
@@ -577,12 +559,8 @@ def send_request():
   \"dir\": \"des\"
 }" \
     start:=0 \
-    status_conjunction="or" \
     start_date="2017-07-31T06:00:00.000Z" \
     limit:=25 \
-    line_item_status:="[
-  \"unallocated\"
-]" \
     end_date="2018-08-03T06:00:00.000Z")
         )
         print('Response HTTP Status Code: {status_code}'.format(
@@ -635,7 +613,7 @@ def send_request():
     .on('error', (error) => {
         callback(error);
     });
-    request.write("{\"start\":0,\"limit\":25,\"sort\":{\"key\":\"uuid\",\"dir\":\"des\"},\"line_item_status\":[\"unallocated\"],\"status_conjunction\":\"or\",\"start_date\":\"2017-07-31T06:00:00.000Z\",\"end_date\":\"2018-08-03T06:00:00.000Z\"}")
+    request.write("{\"start\":0,\"limit\":25,\"sort\":{\"key\":\"uuid\",\"dir\":\"des\"},\"start_date\":\"2017-07-31T06:00:00.000Z\",\"end_date\":\"2018-08-03T06:00:00.000Z\"}")
     request.end();
 
 


### PR DESCRIPTION
These changes aren't live yet, so it doesn't make sense to have them
included. Especially if our potential clients are testing out the API
now.

No associated task